### PR TITLE
Fix play button hovering in low-width windows and title page poster images in title_simple-logo

### DIFF
--- a/base.css
+++ b/base.css
@@ -77,12 +77,19 @@ div[data-role="controlgroup"] a[data-role="button"] {
     background-color: rgba(0, 0, 0, 0.7);
   }
 }
+/* Play button hovering (for low width windows) */
 @media all and (max-width: 70em){
+  .cardOverlayFab-primary {
+    background-color: #00000000;
+  }
   .cardOverlayButtonIcon {
-    background-color: rgba(0, 0, 0, 0.5) !important;
+    background-color: #00000000 !important;
+  }
+  .cardOverlayContainer {
+    background-color: rgba(0, 0, 0, 0.7);
   }
   .cardOverlayButton {
-    padding: 0.5em;
+    padding: 0.25em;
   }
 }
 

--- a/titlepage/title_simple-logo.css
+++ b/titlepage/title_simple-logo.css
@@ -17,6 +17,12 @@
 .layout-desktop .detailRibbon {
   background: rgba(0,0,0,0) !important;
 }
+
+/* Fix poster image not showing in high width windows */
+.layout-desktop .detailImageContainer .card {
+  top: 18vh;
+}
+
 @media all and (min-width: 32em){
   .itemBackdrop {
     display: none;


### PR DESCRIPTION
- Play button hovering in low-width windows matches the look in high-width windows.
  Before the fix:
  ![hovering1](https://user-images.githubusercontent.com/67946485/174532537-0eac3d9b-0673-4df2-b0e2-5a3c3ab9544a.png)
  ![hovering2](https://user-images.githubusercontent.com/67946485/174532546-b5fef26b-055a-4e1f-825f-2a2d6d7c9b0d.png)
  After the fix:
  ![hovering_fix1](https://user-images.githubusercontent.com/67946485/174532575-0be68c33-864b-46c5-8881-926a4b8ffc32.png)
  ![hovering_fix2](https://user-images.githubusercontent.com/67946485/174532592-2ac85dc2-0aef-47a8-a4b2-fac75a8f4726.png)
  I fixed it by essentially just copying over what was already being done for the high-width windows. My CSS isn't great so maybe there are some unintended consequences here but I haven't noticed any.

- Fix poster image not showing up in high-width windows when using title_simple-logo (for title pages).
  Before the fix:
  ![titlepage](https://user-images.githubusercontent.com/67946485/174532798-caa07eec-b9cb-4e1b-b38e-5740aeb0cbee.png)
  After the fix:
  ![titlepage_fix](https://user-images.githubusercontent.com/67946485/174532811-15a4030d-9f3f-40cb-a885-028e35d57027.png)
  This was fixed by just copying over one of the lines from the other presets into this one. I'm not really sure why this only affected high-width windows.