### PR TITLE
fix: remove redundant overflow-y rules in header_transparent.css

### DIFF
--- a/header/header_transparent.css
+++ b/header/header_transparent.css
@@ -1,32 +1,3 @@
 .skinHeader-withBackground {
     background-color: transparent;
 }
-
-/*Pages the have single unit height taskbar*/
-@media all and (min-width: 100em){
-  #indexPage,
-  #moviesPage,
-  #tvRecommendedPage,
-  #musicRecommendedPage {
-    margin-top: 68px;
-    padding-top: 0px !important;
-    overflow-y: scroll;
-  }
-}
-
-/*Pages the have two unit height taskbar*/
-@media all and (max-width: 100em){
-  #indexPage,
-  #moviesPage,
-  #tvRecommendedPage,
-  #musicRecommendedPage {
-    margin-top: 130px;
-    padding-top: 0.5em !important;
-    overflow-y: scroll;
-  }
-}
-
-.force-scroll {
-    overflow-y: auto;
-    overflow-x: auto;
-}


### PR DESCRIPTION
This addresses the unintended horizontal scrollbar/wobble on the home  and library pages by removing forced overflow-y declarations  within media queries.

- Fixes #125 