### PR TITLE
Addresses issue #132. 

### DIFF
--- a/effects/hoverglow.css
+++ b/effects/hoverglow.css
@@ -17,3 +17,6 @@
     box-shadow: 0px 0px 5px rgba(var(--accent), 1) !important;
     border-right: solid 1px rgba(var(--accent), 1) !important;
 }
+.cardBox:hover .cardContent {
+    box-shadow: 0px 0px 5px rgb(var(--accent)) !important;
+}


### PR DESCRIPTION
Since the Jellyfin 10.11+ update changed the web-component container structure, the hover state no longer correctly bubbles up to the entire card layout. This single-line adjustment targets `.cardBox:hover` directly to ensure the glow radiates across the full panel container without interfering with card click actions.

### Changes
- Updated `effects/hoverglow.css` to correctly hook into the updated 10.11+ DOM layout.