### PR TITLE
A better fix for the hoverglow fix

### DIFF
--- a/effects/hoverglow.css
+++ b/effects/hoverglow.css
@@ -3,7 +3,8 @@
     box-shadow: 0px 0px 5px rgba(var(--accent), 0) !important;
     border: solid 1px rgba(var(--accent),0) !important;
 }
-.cardOverlayContainer:hover,
+
+.cardBox:hover .cardOverlayContainer,
 .dialog,
 .toast,
 .raised.homeLibraryButton:hover {
@@ -16,7 +17,4 @@
 .drawer-open {
     box-shadow: 0px 0px 5px rgba(var(--accent), 1) !important;
     border-right: solid 1px rgba(var(--accent), 1) !important;
-}
-.cardBox:hover .cardContent {
-    box-shadow: 0px 0px 5px rgb(var(--accent)) !important;
 }


### PR DESCRIPTION
This updated fix replaces .cardOverlayContainer:hover for .cardbox:hover and adds the glow to .cardOverlayContainer instead of .cardContent for a brighter glow and less code.

The way I should have done this from the start.